### PR TITLE
Fix code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/scripts/Base/tooltip.js
+++ b/scripts/Base/tooltip.js
@@ -3,7 +3,7 @@ $(document).ready(function () {
 	$(".tooltip").live({
 		mouseenter : function (e) {
 			var tip = $('#tooltip');
-			tip.html($(this).attr('data-tooltip-content'));
+			tip.text($(this).attr('data-tooltip-content'));
 			tip.show();
 		},
 		mouseleave : function () {
@@ -32,7 +32,7 @@ $(document).ready(function () {
 	});
 	$(".tooltip_sticky").live('mouseenter', function (e) {
 		var tip = $('#tooltip');
-		tip.html($(this).attr('data-tooltip-content'));
+		tip.text($(this).attr('data-tooltip-content'));
 		tip.addClass('tooltip_sticky_div');
 		tip.css({
 			top : e.pageY - tip.outerHeight() / 2,


### PR DESCRIPTION
Fixes [https://github.com/Apocalypsecoder0/Testwebgame/security/code-scanning/2](https://github.com/Apocalypsecoder0/Testwebgame/security/code-scanning/2)

To fix the problem, we need to ensure that the content of the `data-tooltip-content` attribute is properly escaped before being inserted into the HTML. Instead of using the `html()` method, which can interpret the content as HTML, we should use the `text()` method to treat the content as plain text. This will prevent any HTML tags or scripts from being executed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
